### PR TITLE
Associated types

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,21 @@ use std::rc::Rc;
 struct H;
 impl HashMethods for H {
   type Node = DefaultNode;
-  fn leaf(&self, leaf: &PartialNode, _roots: &[Rc<DefaultNode>]) -> Vec<u8> {
+  type Hash = Vec<u8>;
+
+  fn leaf(&self, leaf: &PartialNode, _roots: &[Rc<DefaultNode>]) -> Self::Hash {
     let data = leaf.as_ref().unwrap();
     sha256::hash(&data).0.to_vec()
   }
 
-  fn parent(&self, a: &DefaultNode, b: &DefaultNode) -> Vec<u8> {
-    let mut buf: Vec<u8> = Vec::with_capacity(a.hash().len() + b.hash().len());
+  fn parent(&self, a: &DefaultNode, b: &DefaultNode) -> Self::Hash {
+    let mut buf = Vec::with_capacity(a.hash().len() + b.hash().len());
     buf.extend_from_slice(a.hash());
     buf.extend_from_slice(b.hash());
     sha256::hash(&buf).0.to_vec()
   }
 
-  fn node(&self, partial: &PartialNode, hash: Vec<u8>) -> DefaultNode {
+  fn node(&self, partial: &PartialNode, hash: Self::Hash) -> DefaultNode {
     DefaultNode::from_partial(partial, hash)
   }
 }

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ use merkle_tree_stream::{HashMethods, DefaultNode, MerkleTreeStream, Node,
 use rust_sodium::crypto::hash::sha256;
 use std::rc::Rc;
 
-struct S;
-impl HashMethods<DefaultNode> for S {
+struct H;
+impl HashMethods for H {
+  type Node = DefaultNode;
   fn leaf(&self, leaf: &PartialNode, _roots: &[Rc<DefaultNode>]) -> Vec<u8> {
     let data = leaf.as_ref().unwrap();
     sha256::hash(&data).0.to_vec()
@@ -48,7 +49,7 @@ impl HashMethods<DefaultNode> for S {
 
 fn main() {
   let roots = Vec::new();
-  let mut mts = MerkleTreeStream::new(S, roots);
+  let mut mts = MerkleTreeStream::new(H, roots);
   let mut nodes: Vec<Rc<DefaultNode>> = Vec::new();
   mts.next(b"hello", &mut nodes);
   mts.next(b"hashed", &mut nodes);

--- a/README.md
+++ b/README.md
@@ -32,27 +32,27 @@ impl HashMethods for H {
   type Node = DefaultNode;
   type Hash = Vec<u8>;
 
-  fn leaf(&self, leaf: &PartialNode, _roots: &[Rc<DefaultNode>]) -> Self::Hash {
+  fn leaf(&self, leaf: &PartialNode, _roots: &[Rc<Self::Node>]) -> Self::Hash {
     let data = leaf.as_ref().unwrap();
     sha256::hash(&data).0.to_vec()
   }
 
-  fn parent(&self, a: &DefaultNode, b: &DefaultNode) -> Self::Hash {
+  fn parent(&self, a: &Self::Node, b: &Self::Node) -> Self::Hash {
     let mut buf = Vec::with_capacity(a.hash().len() + b.hash().len());
     buf.extend_from_slice(a.hash());
     buf.extend_from_slice(b.hash());
     sha256::hash(&buf).0.to_vec()
   }
 
-  fn node(&self, partial: &PartialNode, hash: Self::Hash) -> DefaultNode {
-    DefaultNode::from_partial(partial, hash)
+  fn node(&self, partial: &PartialNode, hash: Self::Hash) -> Self::Node {
+    Self::Node::from_partial(partial, hash)
   }
 }
 
 fn main() {
   let roots = Vec::new();
   let mut mts = MerkleTreeStream::new(H, roots);
-  let mut nodes: Vec<Rc<DefaultNode>> = Vec::new();
+  let mut nodes = vec![];
   mts.next(b"hello", &mut nodes);
   mts.next(b"hashed", &mut nodes);
   mts.next(b"world", &mut nodes);

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -7,28 +7,30 @@ use merkle_tree_stream::{
 use rust_sodium::crypto::hash::sha256;
 use std::rc::Rc;
 
-struct S;
-impl HashMethods<DefaultNode> for S {
-  fn leaf(&self, leaf: &PartialNode, _roots: &[Rc<DefaultNode>]) -> Vec<u8> {
+struct H;
+impl HashMethods for H {
+  type Node = DefaultNode;
+
+  fn leaf(&self, leaf: &PartialNode, _roots: &[Rc<Self::Node>]) -> Vec<u8> {
     let data = leaf.as_ref().unwrap();
     sha256::hash(&data).0.to_vec()
   }
 
-  fn parent(&self, a: &DefaultNode, b: &DefaultNode) -> Vec<u8> {
+  fn parent(&self, a: &Self::Node, b: &Self::Node) -> Vec<u8> {
     let mut buf: Vec<u8> = Vec::with_capacity(a.hash().len() + b.hash().len());
     buf.extend_from_slice(a.hash());
     buf.extend_from_slice(b.hash());
     sha256::hash(&buf).0.to_vec()
   }
 
-  fn node(&self, partial: &PartialNode, hash: Vec<u8>) -> DefaultNode {
+  fn node(&self, partial: &PartialNode, hash: Vec<u8>) -> Self::Node {
     // Cloning the data in the reference because we don't own it.
     let data = match partial.data() {
       Some(data) => Some(data.clone()),
       None => None,
     };
 
-    DefaultNode {
+    Self::Node {
       index: partial.index(),
       parent: partial.parent,
       length: partial.len(),
@@ -40,8 +42,8 @@ impl HashMethods<DefaultNode> for S {
 
 fn main() {
   let roots = Vec::new();
-  let mut mts = MerkleTreeStream::new(S, roots);
-  let mut nodes: Vec<Rc<DefaultNode>> = Vec::new();
+  let mut mts = MerkleTreeStream::new(H, roots);
+  let mut nodes = Vec::new();
   mts.next(b"hello", &mut nodes);
   mts.next(b"hashed", &mut nodes);
   mts.next(b"world", &mut nodes);

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -18,7 +18,7 @@ impl HashMethods for H {
   }
 
   fn parent(&self, a: &Self::Node, b: &Self::Node) -> Self::Hash {
-    let mut buf: Self::Hash = Vec::with_capacity(a.hash().len() + b.hash().len());
+    let mut buf = Vec::with_capacity(a.hash().len() + b.hash().len());
     buf.extend_from_slice(a.hash());
     buf.extend_from_slice(b.hash());
     sha256::hash(&buf).0.to_vec()

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -10,20 +10,21 @@ use std::rc::Rc;
 struct H;
 impl HashMethods for H {
   type Node = DefaultNode;
+  type Hash = Vec<u8>;
 
-  fn leaf(&self, leaf: &PartialNode, _roots: &[Rc<Self::Node>]) -> Vec<u8> {
+  fn leaf(&self, leaf: &PartialNode, _roots: &[Rc<Self::Node>]) -> Self::Hash {
     let data = leaf.as_ref().unwrap();
     sha256::hash(&data).0.to_vec()
   }
 
-  fn parent(&self, a: &Self::Node, b: &Self::Node) -> Vec<u8> {
-    let mut buf: Vec<u8> = Vec::with_capacity(a.hash().len() + b.hash().len());
+  fn parent(&self, a: &Self::Node, b: &Self::Node) -> Self::Hash {
+    let mut buf: Self::Hash = Vec::with_capacity(a.hash().len() + b.hash().len());
     buf.extend_from_slice(a.hash());
     buf.extend_from_slice(b.hash());
     sha256::hash(&buf).0.to_vec()
   }
 
-  fn node(&self, partial: &PartialNode, hash: Vec<u8>) -> Self::Node {
+  fn node(&self, partial: &PartialNode, hash: Self::Hash) -> Self::Node {
     // Cloning the data in the reference because we don't own it.
     let data = match partial.data() {
       Some(data) => Some(data.clone()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,14 +18,14 @@ use std::rc::Rc;
 pub trait HashMethods {
   /// The Node type we'll iterate over.
   type Node: Node;
-  // /// The Hash type that's passed around.
-  // type Hash;
+  /// The type of hash returned from the hashing functions.
+  type Hash;
   /// Pass data through a hash function.
-  fn leaf(&self, leaf: &PartialNode, roots: &[Rc<Self::Node>]) -> Vec<u8>;
+  fn leaf(&self, leaf: &PartialNode, roots: &[Rc<Self::Node>]) -> Self::Hash;
   /// Pass hashes through a hash function.
-  fn parent(&self, a: &Self::Node, b: &Self::Node) -> Vec<u8>;
+  fn parent(&self, a: &Self::Node, b: &Self::Node) -> Self::Hash;
   /// Combine a `PartialNode` and a `Hash` to a `Node` type.
-  fn node(&self, partial_node: &PartialNode, hash: Vec<u8>) -> Self::Node;
+  fn node(&self, partial_node: &PartialNode, hash: Self::Hash) -> Self::Node;
 }
 
 /// Functions that need to be implemented for the Data that `MerkleTreeStream`

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -17,20 +17,21 @@ use std::rc::Rc;
 struct H;
 impl HashMethods for H {
   type Node = DefaultNode;
+  type Hash = Vec<u8>;
 
-  fn leaf(&self, leaf: &PartialNode, _roots: &[Rc<Self::Node>]) -> Vec<u8> {
+  fn leaf(&self, leaf: &PartialNode, _roots: &[Rc<Self::Node>]) -> Self::Hash {
     let data = leaf.as_ref().unwrap();
     sha256::hash(&data).0.to_vec()
   }
 
-  fn parent(&self, a: &Self::Node, b: &Self::Node) -> Vec<u8> {
-    let mut buf: Vec<u8> = Vec::with_capacity(a.hash().len() + b.hash().len());
+  fn parent(&self, a: &Self::Node, b: &Self::Node) -> Self::Hash {
+    let mut buf = Vec::with_capacity(a.hash().len() + b.hash().len());
     buf.extend_from_slice(a.hash());
     buf.extend_from_slice(b.hash());
     sha256::hash(&buf).0.to_vec()
   }
 
-  fn node(&self, partial: &PartialNode, hash: Vec<u8>) -> Self::Node {
+  fn node(&self, partial: &PartialNode, hash: Self::Hash) -> Self::Node {
     DefaultNode::from_partial(partial, hash)
   }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -120,12 +120,10 @@ fn mts_more_nodes() {
   }
 }
 
-fn build_mts(
-  data: &[Vec<u8>],
-) -> (MerkleTreeStream<S, DefaultNode>, Vec<Rc<DefaultNode>>) {
-  let roots = Vec::new();
-  let mut mts = MerkleTreeStream::new(S, roots);
-  let mut nodes: Vec<Rc<DefaultNode>> = Vec::new();
+fn build_mts(data: &[Vec<u8>]) -> (MerkleTreeStream<H>, Vec<Rc<DefaultNode>>) {
+  let roots = vec![];
+  let mut mts = MerkleTreeStream::new(H, roots);
+  let mut nodes = vec![];
 
   data.iter().for_each(|bs| mts.next(&bs, &mut nodes));
   (mts, nodes)
@@ -134,10 +132,10 @@ fn build_mts(
 fn all_children(index: usize) -> Box<Iterator<Item = usize>> {
   let self_ = iter::once(index);
   match flat_tree::children(index) {
+    None => Box::new(self_),
     Some((left, right)) => {
       Box::new(self_.chain(all_children(left)).chain(all_children(right)))
     }
-    None => Box::new(self_),
   }
 }
 
@@ -185,7 +183,7 @@ fn roots_are_subset_of_nodes() {
     let (mts, nodes) = build_mts(&data);
     let roots: HashSet<_> =
       mts.roots().iter().map(|root| root.index()).collect();
-    let nodes: HashSet<_> = nodes.iter().map(|node| node.index()).collect();
+    let nodes = nodes.iter().map(|node| node.index()).collect();
 
     roots.is_subset(&nodes)
   }


### PR DESCRIPTION
This should make the code easier to write & reason about.

- Allows configuring the returned hash type (instead of locking it to `Vec<u8>` which should remove some overhead.
- Removes the type parameter in favor of an associated type on the trait.
- Has the fun result that the trait's arguments are now a lot cleaner too.
- Fixes #10

Thanks!