### PR TITLE
 Keep up with modern times in clippy invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ rust:
 
 before_script: |
   rustup component add rustfmt-preview &&
-  cargo install clippy -f
+  rustup component add clippy-preview
 script: |
-  cargo clippy -- -D clippy &&
+  cargo clippy -- -D clippy::all &&
   cargo build --verbose &&
   cargo test  --verbose
 cache: cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_script: |
   rustup component add rustfmt-preview &&
   rustup component add clippy-preview
 script: |
+  cargo fmt -- --check &&
   cargo clippy -- -D clippy::all &&
   cargo build --verbose &&
   cargo test  --verbose


### PR DESCRIPTION
This is a 🐛 bug fix.

Fixes the following warning:
`warning: lint name `clippy` is deprecated and does not have an effect anymore. Use: clippy::all`

Also, run rustfmt check on travis.

## Checklist

- [x] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Semver Changes
None