### PR TITLE
Use NodeKind enum instead of Option for PartialNode data

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,7 +1,7 @@
 extern crate merkle_tree_stream;
 
 use merkle_tree_stream::{
-  DefaultNode, HashMethods, MerkleTreeStream, Node, PartialNode,
+  DefaultNode, HashMethods, MerkleTreeStream, Node, NodeKind, PartialNode,
 };
 use std::rc::Rc;
 use std::vec::Vec;
@@ -13,7 +13,10 @@ impl HashMethods for XorHashMethods {
 
   fn leaf(&self, leaf: &PartialNode, _roots: &[Rc<Self::Node>]) -> Self::Hash {
     // bitwise XOR the data into u8
-    leaf.as_ref().unwrap().iter().fold(0, |acc, x| acc ^ x)
+    match leaf.data() {
+      NodeKind::Parent => 0,
+      NodeKind::Leaf(data) => data.iter().fold(0, |acc, x| acc ^ x),
+    }
   }
 
   fn parent(&self, a: &Self::Node, b: &Self::Node) -> Self::Hash {

--- a/src/default_node.rs
+++ b/src/default_node.rs
@@ -1,4 +1,4 @@
-use super::{Node, PartialNode};
+use super::{Node, NodeKind, PartialNode};
 use std::ops::{Deref, DerefMut};
 
 /// Node representation.
@@ -20,8 +20,8 @@ impl DefaultNode {
   /// Convert a `PartialNode` to a `Node`.
   pub fn from_partial(partial: &PartialNode, hash: Vec<u8>) -> Self {
     let data = match partial.data() {
-      Some(data) => Some(data.clone()),
-      None => None,
+      NodeKind::Leaf(data) => Some(data.clone()),
+      NodeKind::Parent => None,
     };
 
     Self {

--- a/src/partial_node.rs
+++ b/src/partial_node.rs
@@ -1,5 +1,13 @@
 use std::ops::{Deref, DerefMut};
 
+/// Custom Option type that encodes the presence or absense of data at this node
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd, Clone)]
+pub enum NodeKind {
+  /// No data, only children
+  Parent,
+  /// Contains data
+  Leaf(Vec<u8>),
+}
 /// Intermediate Node representation. Same as Node, but without the `.hash`
 /// field.
 #[derive(Debug, Eq, Ord, PartialEq, PartialOrd, Clone)]
@@ -7,7 +15,7 @@ pub struct PartialNode {
   /// Reference to this node's parent node.
   pub parent: usize,
   /// Data if it's a leaf node, nothing if it's a parent node.
-  pub(crate) data: Option<Vec<u8>>,
+  pub(crate) data: NodeKind,
   /// Total size of all its child nodes combined.
   pub(crate) length: usize,
   /// Offset into the flat-tree data structure.
@@ -31,13 +39,13 @@ impl PartialNode {
     self.index
   }
   /// Get the data from the thingy.
-  pub fn data(&self) -> &Option<Vec<u8>> {
+  pub fn data(&self) -> &NodeKind {
     &self.data
   }
 }
 
 impl Deref for PartialNode {
-  type Target = Option<Vec<u8>>;
+  type Target = NodeKind;
   fn deref(&self) -> &Self::Target {
     &self.data
   }


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:** a 🙋 feature

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

## Context
As mentioned in #9, this swaps out the `data: Option<Vec<u8>>` for a new enum called `NodeKind` with two constructors: `Parent` and `Leaf`.

## Semver Changes
This is most certainly a backwards incompatible change, but I'm not sure what the versioning contract is for this module pre 1.0