### PR TITLE
[WIP] Contrain Node as: From<NodeParts>

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -25,10 +25,6 @@ impl HashMethods for XorHashMethods {
       .chain(Node::hash(b).iter())
       .fold(0, |acc, x| acc ^ x)
   }
-
-  fn node(&self, partial_node: &PartialNode, hash: Self::Hash) -> Self::Node {
-    Self::Node::from_partial(partial_node, vec![hash])
-  }
 }
 
 fn main() {

--- a/src/default_node.rs
+++ b/src/default_node.rs
@@ -1,4 +1,4 @@
-use super::{Node, NodeKind, PartialNode};
+use super::{Node, NodeKind, NodeParts, PartialNode};
 use std::ops::{Deref, DerefMut};
 
 /// Node representation.
@@ -53,6 +53,12 @@ impl Node for DefaultNode {
 
   fn parent(&self) -> usize {
     self.parent
+  }
+}
+
+impl From<NodeParts<Vec<u8>>> for DefaultNode {
+  fn from(parts: NodeParts<Vec<u8>>) -> DefaultNode {
+    DefaultNode::from_partial(&parts.node, parts.hash)
   }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -33,10 +33,6 @@ impl HashMethods for H {
     buf.extend_from_slice(b.hash());
     hex_digest(Algorithm::SHA256, &buf).as_bytes().to_vec()
   }
-
-  fn node(&self, partial: &PartialNode, hash: Self::Hash) -> Self::Node {
-    DefaultNode::from_partial(partial, hash)
-  }
 }
 
 #[test]


### PR DESCRIPTION
**Choose one:** a 🙋 feature

As suggested and discussed in #20, this PR removes the `node` method from the `HashMethods` trait and adds a constraint that the `Node` type must implement `From<NodeParts>`. `NodeParts` is a struct that holds the `PartialNode` and the `hash` for constructing a full node.

`DefaultNode` already has a good implementation for this.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
Closes #20 

## Semver Changes
Definitely a breaking change.