### PR TITLE
Change from usize to u64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: rust
 rust:
-  - nightly
+  - stable
 
 before_script: |
-  rustup component add rustfmt-preview &&
-  rustup component add clippy-preview
+  rustup component add rustfmt &&
+  rustup component add clippy
 script: |
   cargo fmt -- --check &&
   cargo clippy -- -D clippy::all &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-flat-tree = "4.0.1"
+flat-tree = { version = "4.1.0", git = "https://github.com/bltavares/flat-tree", branch = "usize-to-u64" }
 
 [dev-dependencies]
-hex = "0.4.0"
-quickcheck = "0.9.0"
-crypto-hash = "0.3.1"
+hex = "0.4.2"
+quickcheck = "0.9.2"
+crypto-hash = "0.3.4"
 async-std = "1.5.0"

--- a/src/default_node.rs
+++ b/src/default_node.rs
@@ -5,15 +5,15 @@ use std::ops::{Deref, DerefMut};
 #[derive(Debug, Eq, Ord, PartialEq, PartialOrd, Clone)]
 pub struct DefaultNode {
   /// Reference to this node's parent node.
-  pub parent: usize,
+  pub parent: u64,
   /// Data if it's a leaf node, nothing if it's a parent node.
   pub data: Option<Vec<u8>>,
   /// Hash of the data
   pub hash: Vec<u8>,
   /// Total size of all its child nodes combined.
-  pub length: usize,
+  pub length: u64,
   /// Offset into the flat-tree data structure.
-  pub index: usize,
+  pub index: u64,
 }
 
 impl DefaultNode {
@@ -39,7 +39,7 @@ impl Node for DefaultNode {
     &self.hash
   }
 
-  fn len(&self) -> usize {
+  fn len(&self) -> u64 {
     self.length
   }
 
@@ -47,11 +47,11 @@ impl Node for DefaultNode {
     self.length == 0
   }
 
-  fn index(&self) -> usize {
+  fn index(&self) -> u64 {
     self.index
   }
 
-  fn parent(&self) -> usize {
+  fn parent(&self) -> u64 {
     self.parent
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,13 +89,13 @@ pub trait HashMethods {
 /// works with.
 pub trait Node {
   /// Get the length of the node.
-  fn len(&self) -> usize;
+  fn len(&self) -> u64;
   /// Check if the length is zero.
   fn is_empty(&self) -> bool;
   /// Get the position of the parent of the node.
-  fn parent(&self) -> usize;
+  fn parent(&self) -> u64;
   /// Get the position at which the node was found.
-  fn index(&self) -> usize;
+  fn index(&self) -> u64;
   /// Get the hash contained in the node.
   fn hash(&self) -> &[u8];
 }
@@ -178,7 +178,7 @@ pub trait Node {
 pub struct MerkleTreeStream<T: HashMethods> {
   handler: T,
   roots: Vec<Arc<T::Node>>,
-  blocks: usize,
+  blocks: u64,
 }
 
 impl<H: HashMethods> MerkleTreeStream<H> {
@@ -194,13 +194,13 @@ impl<H: HashMethods> MerkleTreeStream<H> {
   /// Pass a string buffer through the flat-tree hash functions, and write the
   /// result back out to "nodes".
   pub fn next<'a>(&mut self, data: &[u8], nodes: &'a mut Vec<Arc<H::Node>>) {
-    let index: usize = 2 * self.blocks;
+    let index: u64 = 2 * self.blocks;
     self.blocks += 1;
 
     let leaf = PartialNode {
       index,
-      parent: flat::parent(index) as usize,
-      length: data.len(),
+      parent: flat::parent(index) as u64,
+      length: data.len() as u64,
       data: NodeKind::Leaf(data.to_vec()),
     };
 
@@ -223,7 +223,7 @@ impl<H: HashMethods> MerkleTreeStream<H> {
         let hash = self.handler.parent(left, right);
         let partial = PartialNode {
           index: left.parent(),
-          parent: flat::parent(left.parent()) as usize,
+          parent: flat::parent(left.parent()) as u64,
           length: left.len() + right.len(),
           data: NodeKind::Parent,
         };

--- a/src/partial_node.rs
+++ b/src/partial_node.rs
@@ -13,19 +13,19 @@ pub enum NodeKind {
 #[derive(Debug, Eq, Ord, PartialEq, PartialOrd, Clone)]
 pub struct PartialNode {
   /// Reference to this node's parent node.
-  pub parent: usize,
+  pub parent: u64,
   /// Data if it's a leaf node, nothing if it's a parent node.
   pub(crate) data: NodeKind,
   /// Total size of all its child nodes combined.
-  pub(crate) length: usize,
+  pub(crate) length: u64,
   /// Offset into the flat-tree data structure.
-  pub(crate) index: usize,
+  pub(crate) index: u64,
 }
 
 impl PartialNode {
   /// Returns the number of elements in the Node, also referred to as its
   /// 'length'.
-  pub fn len(&self) -> usize {
+  pub fn len(&self) -> u64 {
     self.length
   }
 
@@ -35,7 +35,7 @@ impl PartialNode {
   }
 
   /// Get the current index into the stream.
-  pub fn index(&self) -> usize {
+  pub fn index(&self) -> u64 {
     self.index
   }
   /// Get the data from the thingy.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -124,7 +124,7 @@ fn build_mts(data: &[Vec<u8>]) -> (MerkleTreeStream<H>, Vec<Arc<DefaultNode>>) {
   (mts, nodes)
 }
 
-fn all_children(index: usize) -> Box<dyn Iterator<Item = usize>> {
+fn all_children(index: u64) -> Box<dyn Iterator<Item = u64>> {
   let self_ = iter::once(index);
   match flat_tree::children(index) {
     None => Box::new(self_),
@@ -218,7 +218,7 @@ fn all_leaves_contain_data() {
 #[test]
 fn hashes_change_when_data_is_changed() {
   /// Finds the parent indices (in-tree IDs) of the nth data block
-  fn parent_indices(nodes: &[Arc<DefaultNode>], n: usize) -> HashSet<usize> {
+  fn parent_indices(nodes: &[Arc<DefaultNode>], n: usize) -> HashSet<u64> {
     let modified_node_index = nodes
       .iter()
       .filter(|node| node.data.is_some())
@@ -241,7 +241,7 @@ fn hashes_change_when_data_is_changed() {
 
   fn partition(
     nodes: Vec<Arc<DefaultNode>>,
-    indices: &HashSet<usize>,
+    indices: &HashSet<u64>,
   ) -> (Vec<Arc<DefaultNode>>, Vec<Arc<DefaultNode>>) {
     nodes
       .into_iter()


### PR DESCRIPTION
On [random-access-storage](https://github.com/datrs/random-access-storage)
issue
https://github.com/datrs/random-access-storage/issues/6 has changed all
types from `usize` into `u64` to be able to handle more than 4gbs on
32bits systems.

> usize is 32 bits on a 32 bit system, so the storage would be limited
to 4GB on such a system.

When changing `random-access-storage` on `hypercore` (tracking:
https://github.com/datrs/hypercore/pull/100) one of the things I've
noticed is that it wold be easier to also make `merkle-tree-stream` use
`u64` to integrate with `random-access-storage`. Very likely, this also
means that we would need to bump to use more than 32Gb storages on
`merkle-tree-stream`.

I've simply changed all declarations of usize into u64. All tests are
passing.

Needs:
---

- [ ] https://github.com/datrs/flat-tree/pull/44

<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:** is this a 🐛 bug fix, a 🙋 feature, or a 🔦 documentation change?

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
<!-- Is this related to any GitHub issue(s)? -->

## Semver Changes
<!-- Which semantic version change would you recommend? -->
