### PR TITLE
proper initialization for MerkleTreeStream

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,10 +184,18 @@ pub struct MerkleTreeStream<T: HashMethods> {
 impl<H: HashMethods> MerkleTreeStream<H> {
   /// Create a new MerkleTreeStream instance.
   pub fn new(handler: H, roots: Vec<Arc<H::Node>>) -> MerkleTreeStream<H> {
+    let blocks = if !roots.is_empty() {
+      // Cant panic because roots.len() > 0
+      let root = roots.last().unwrap();
+      1 + flat::right_span(root.index()) / 2
+    } else {
+      0
+    };
+
     MerkleTreeStream {
       handler,
       roots,
-      blocks: 0,
+      blocks,
     }
   }
 
@@ -247,5 +255,10 @@ impl<H: HashMethods> MerkleTreeStream<H> {
   /// Get the roots vector.
   pub fn roots(&self) -> &Vec<Arc<H::Node>> {
     &self.roots
+  }
+
+  /// Get number of blocks
+  pub fn blocks(&self) -> u64 {
+    self.blocks
   }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -282,3 +282,18 @@ fn hashes_change_when_data_is_changed() {
   }
   quickcheck(prop as fn(Vec<u8>, Vec<Vec<u8>>, usize, Vec<u8>) -> bool);
 }
+
+#[test]
+fn mts_new_with_nodes() {
+  let roots = vec![Arc::new(DefaultNode {
+    parent: 0,
+    data: Some(b"test".to_vec()),
+    hash: vec![],
+    length: 4,
+    index: 0,
+  })];
+
+  let mts = MerkleTreeStream::new(H, roots);
+
+  assert_eq!(mts.blocks(), 1);
+}


### PR DESCRIPTION
a 🐛 bug fix
Proper initialization of `MerkleTreeStream`

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
this fixes reading feeds in datrs/hypercore

## Semver Changes
patch level? this doesnt break anything
